### PR TITLE
Remove deprecated property

### DIFF
--- a/src/FirebaseClientService.js
+++ b/src/FirebaseClientService.js
@@ -56,8 +56,10 @@ export default class FirebaseService extends ImageService {
           function(e) {
             onError(e);
           },
-          function() {
-            onSuccess({ data: { link: uploadTask.snapshot.downloadURL } });
+          function () {
+            uploadTask.snapshot.ref.getDownloadURL().then(downloadURL => {
+              onSuccess({data: {link: downloadURL}});
+            });
           }
         );
       }.bind(this)


### PR DESCRIPTION
Remove deprecated property downloadUrl and use getDownloadURL() method instead.
Otherwise response is 
{
data: {link: undefined}
}